### PR TITLE
Use Travis to audit and test formulae

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+os: osx
+before_install:
+  - brew update
+install:
+  - brew install nodenv
+script:
+  - ./script/run-travis.sh

--- a/nodenv-npm-rehash.rb
+++ b/nodenv-npm-rehash.rb
@@ -1,8 +1,9 @@
 class NodenvNpmRehash < Formula
+  desc "Automatically runs `nodenv rehash`"
   homepage "https://github.com/jawshooah/nodenv-npm-rehash"
-  head "https://github.com/jawshooah/nodenv-npm-rehash.git"
   url "https://github.com/jawshooah/nodenv-npm-rehash/archive/0.1.0.tar.gz"
   sha256 "df7d20a09e9ed17ca98ee87b70dd371a7beed12eb2c099d110458a72d2e816d1"
+  head "https://github.com/jawshooah/nodenv-npm-rehash.git"
 
   depends_on "nodenv"
 
@@ -12,6 +13,6 @@ class NodenvNpmRehash < Formula
   end
 
   test do
-    assert shell_output("nodenv hooks exec").include? "npm.bash"
+    assert_match /npm\.bash/, shell_output("nodenv hooks exec")
   end
 end

--- a/script/run-travis.sh
+++ b/script/run-travis.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -o errexit
+shopt -s extglob
+
+for formula in ./!(nodenv-vars).rb; do
+  brew audit --strict "$formula"
+  brew install "$formula"
+  brew test "$formula"
+done


### PR DESCRIPTION
Following a suggestion in #9, this adds a Travis config file and corresponding script to audit, install, and test all formulae.

We're excluding `nodenv-vars` here because it is head-only, which means it can [only be audited](https://github.com/Homebrew/homebrew/pull/41289) in a tap with a name ending in `head-only`.